### PR TITLE
Node10

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,6 +33,10 @@
             '<(node_root_dir)/deps/openssl/openssl/include',
                         "<!(node -e \"require('nan')\")"
           ],
+          "libraries": [
+            "-lssl",
+            "-lcrypto"
+          ]
         }],
       ],
     }


### PR DESCRIPTION
this fixes `ursaNative.node: undefined symbol: RSA_new` error on Ubuntu 18 with libssl 1.1.0 and Electron.